### PR TITLE
Use HTTPS URL.

### DIFF
--- a/znc/README
+++ b/znc/README
@@ -21,7 +21,7 @@ Thanks to prozac we have a working znc module that pushes priv messages and hili
 
 To install make sure you have znc installed and configured, then run the following:
 
-	$ wget http://github.com/wired/colloquypush/raw/master/znc/colloquy.cpp
+	$ wget https://github.com/wired/colloquypush/raw/master/znc/colloquy.cpp
 	$ znc-buildmod colloquy.cpp
 	$ mv colloquy.so ~/.znc/modules/
 


### PR DESCRIPTION
Let's not encourage people to run unauthenticated C++ code from the Internet on their servers.
