### PR TITLE
Fixed build error with ZNC 1.6.2

### DIFF
--- a/znc/colloquy.cpp
+++ b/znc/colloquy.cpp
@@ -775,7 +775,7 @@ public:
 		}
 
 		bool bRet = true;
-		vector<CClient*>& vpClients = GetNetwork()->GetClients();
+		vector<CClient*> const& vpClients = GetNetwork()->GetClients();
 
 		// Cycle through all of the cached devices
 		for (map<CString, CDevice*>::iterator it = m_mspDevices.begin(); it != m_mspDevices.end(); it++) {


### PR DESCRIPTION
When building the module with znc-buildmod with ZNC 1.6.2 this produced an error:

Building "colloquy.so" for ZNC 1.6.2... colloquy.cpp: In member function ‘bool CColloquyMod::Push(const CString&, const CString&, const CString&, bool, int)’:
colloquy.cpp:778:58: error: invalid initialization of reference of type ‘std::vector<CClient*>&’ from expression of type ‘const std::vector<CClient*>’
   vector<CClient*>& vpClients = GetNetwork()->GetClients();

Seems like GetClients() returns a const reference and the module was not handling that properly. Since vpClients is used read-only making it const did not break anything and it works that way.
